### PR TITLE
Fix an issue with IE8 and an undefined list of values

### DIFF
--- a/pinkyswear.js
+++ b/pinkyswear.js
@@ -97,7 +97,7 @@
 		   							promise2(false, [e]);
 		   					}
 		   				}
-		   				resolve(f.apply(undef, values));
+		   				resolve(f.apply(undef, values || []));
 		   			}
 		   			else
 		   				promise2(state, values);


### PR DESCRIPTION
The IE8 Function.apply method errors out with an undefined value as the array of parameters
