### PR TITLE
Support for deferring using setImmediate

### DIFF
--- a/pinkyswear-additional-functionality-test.js
+++ b/pinkyswear-additional-functionality-test.js
@@ -1,7 +1,9 @@
 var pinkySwear = require('./pinkyswear');
 var assert = require('assert');
+var global = new Function("return this")();
 
 describe('additional functionality', function () {
+	this.timeout(100);
 
 	it('should pass multiple arguments on to the resolver function (1)', function (done) {
 
@@ -9,9 +11,9 @@ describe('additional functionality', function () {
 		p(true, [3, 2, 1]);
 
 		p.then(function (r1, r2, r3) {
-			assert.equal(r1,3);
-			assert.equal(r2,2);
-			assert.equal(r3,1);
+			assert.equal(r1, 3);
+			assert.equal(r2, 2);
+			assert.equal(r3, 1);
 			done();
 		}).error(done);
 	});
@@ -25,11 +27,18 @@ describe('additional functionality', function () {
 			return p;
 		})
 			.then(function (r1, r2, r3) {
-				assert.equal(r1,3);
-				assert.equal(r2,2);
-				assert.equal(r3,1);
+				assert.equal(r1, 3);
+				assert.equal(r2, 2);
+				assert.equal(r3, 1);
 				done();
 			})
 			.error(done);
+	});
+
+	it('should use setImmediate if available', function (done) {
+		global.setImmediate = done.bind(null,null);
+		var p = pinkySwear();
+		p(true);
+		p.then(function() {  })
 	});
 });

--- a/pinkyswear.js
+++ b/pinkyswear.js
@@ -43,7 +43,7 @@
  */
 (function(target) {
 	var undef;
-	
+
 	function isFunction(f) {
 		return typeof f == 'function';
 	}
@@ -51,12 +51,14 @@
 		return typeof f == 'object';
 	}
 	function defer(callback) {
-		if (typeof process != 'undefined' && process['nextTick'])
+		if(setImmediate)
+			setImmediate(callback);
+		else if (typeof process != 'undefined' && process['nextTick'])
 			process['nextTick'](callback);
 		else
 			setTimeout(callback, 0);
 	}
-	
+
 	target[0][target[1]] = function pinkySwear() {
 		var state;           // undefined/null = pending, true = fulfilled, false = rejected
 		var values = [];     // an array of values as arguments for the then() handlers
@@ -74,7 +76,7 @@
 			}
 			return state;
 		};
-		
+
 		set['then'] = function (onFulfilled, onRejected) {
 			var promise2 = pinkySwear();
 			var callCallbacks = function() {
@@ -95,7 +97,7 @@
 				   					promise2(true, arguments);
 		   					}
 		   					catch(e) {
-		   						if (!cbCalled++) 
+		   						if (!cbCalled++)
 		   							promise2(false, [e]);
 		   					}
 		   				}
@@ -111,7 +113,7 @@
 			if (state != null)
 				defer(callCallbacks);
 			else
-				deferred.push(callCallbacks);    		
+				deferred.push(callCallbacks);
 			return promise2;
 		};
 


### PR DESCRIPTION
Added support for running using setImmediate - if available. Some browser support + efficient shims.

Increased the execution speed of the tests for my promises-based framework by 70x (274ms -> 4ms).

Shims and more info at http://jphpsf.github.io/setImmediate-shim-demo

A future addition might be to include support for MutationObserver, which is now available in all browsers.
