### PR TITLE
Enabled extending the API of returned promises

### DIFF
--- a/pinkyswear.js
+++ b/pinkyswear.js
@@ -51,7 +51,7 @@
 			setTimeout(callback, 0);
 	}
 
-	target[0][target[1]] = function pinkySwear() {
+	target[0][target[1]] = function pinkySwear(extend) {
 		var state;           // undefined/null = pending, true = fulfilled, false = rejected
 		var values = [];     // an array of values as arguments for the then() handlers
 		var deferred = [];   // functions to call when set() is invoked
@@ -108,6 +108,9 @@
 				deferred.push(callCallbacks);
 			return promise2;
 		};
+        if(extend){
+            set = extend(set);
+        }
 		return set;
 	};
 })(typeof module == 'undefined' ? [window, 'pinkySwear'] : [module, 'exports']);


### PR DESCRIPTION
I have used your implementation of promises to build a JS SDK on top of my company's public API. I need the promise to have something mode than just `then` function and the current code is immune to extensions.

This pull request is one way it can be done. I need to have at least the `error` method, otherwise I'll need to replace pinkyswear with something else, or maintain a fork.
