### PR TITLE
Updated dev dependencies to avoid security vulnerabilities raised by nsp check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Minimalistic Promises/A+ implementation, <500 bytes",
   "main": "pinkyswear.js",
   "devDependencies": {
-    "promises-aplus-tests": "~2.0.4",
-    "mocha": "^1.18.2"
+    "mocha": "^3.3.0",
+    "promises-aplus-tests": "^2.1.2"
   },
   "scripts": {
     "test": "node promise-test.js pinkyswear.js; node promise-test.js pinkyswear.min.js; mocha pinkyswear-additional-functionality-test.js"


### PR DESCRIPTION
`nsp check` complains about security vulnerabilities in devDependencies. 

They are:

- "Regular Expression Denial of Service" in `minimatch` from `promises-aplus-tests`
- "Regular Expression Denial of Service" in `ms` from `promises-aplus-tests`

Both mocha and promises-aplus-tests got updated.